### PR TITLE
Filename Sanitization

### DIFF
--- a/src/Madnest/Madzipper/Madzipper.php
+++ b/src/Madnest/Madzipper/Madzipper.php
@@ -613,6 +613,10 @@ class Madzipper
     {
         $tmpPath = str_replace($this->getInternalPath(), '', $fileName);
 
+        //Prevent Zip traversal attacks
+        if (strpos($fileName, '../') !== false || strpos($fileName, '..\\') !== false) {
+            throw new \RuntimeException('Special characters found within filenames');
+        }
         // We need to create the directory first in case it doesn't exist
         $dir = pathinfo($path . DIRECTORY_SEPARATOR . $tmpPath, PATHINFO_DIRNAME);
         if (!$this->file->exists($dir) && !$this->file->makeDirectory($dir, 0755, true, true)) {


### PR DESCRIPTION
Checks for special characters within filenames within a ZIP file using strpos comparison to prevent Zip Traversal Attacks.