### PR TITLE
catch ValueError when closing the Zip Object

### DIFF
--- a/src/Madnest/Madzipper/Madzipper.php
+++ b/src/Madnest/Madzipper/Madzipper.php
@@ -65,7 +65,11 @@ class Madzipper
     public function __destruct()
     {
         if (is_object($this->repository) && $this->repository->isOpen()) {
-            $this->repository->close();
+            try {
+                $this->repository->close();
+            } catch (\ValueError $er) {
+                // seemingly the repository was still unitialized (or already closed?)
+            }
         }
     }
 


### PR DESCRIPTION
Apparently, there are ways to close the Zip object when it's not expected to be closed. This would address #21 and #29