### PR TITLE
Remove the version field from composer.json (v1.7.0 is missing from Packagist)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "madnest/madzipper",
   "description": "Easier zip file handling for Laravel applications.",
   "type": "library",
-  "version": "1.6.0",
   "keywords": [
     "zip",
     "php",


### PR DESCRIPTION
`composer.json` declares `"version": "1.6.0"`, which is why `1.7.0` never reached Packagist — Composer reads that field in preference to the tag name, so tag `v1.7.0` is published as `1.6.0` and the Laravel 13 support from #49 is only reachable via `1.7.x-dev`.

Removing the field lets Packagist derive the version from the tag, as it did for every release through `v1.5.0` (the field was added in 5351d176). `v1.7.0` will still need re-tagging for this to take effect, but afterwards the tag name alone is authoritative, so there's no per-release bump to remember.